### PR TITLE
Add notes regarding protector in upgrades from 2.3

### DIFF
--- a/en/book/upgrade/README.md
+++ b/en/book/upgrade/README.md
@@ -17,6 +17,8 @@ forums at http://xoops.org/modules/newbb/
  - It is wise to turn your site off in System Options - Preferences - General Settings
  - Copy the contents of the distribution htdocs directory into your web root directory. Be careful not to overwrite any customize configuration or theme files.
  - Copy the contents of htdocs/xoops_lib to your relocated/renamed xoops_lib as applicable
+ - Copy the contents of htdocs/xoops_data to your relocated/renamed xoops_data as applicable
+ - If you are upgrading from a pre-2.5 series XOOPS, check your mainfile.php for any old protector modifications and remove if found 
  - Copy the distribution upgrade directory into your web root directory
  - Point your browser to *your-site-url*/upgrade/ and follow the prompts
  - Log in and step through any needed updates with the "Continue" button

--- a/en/book/upgrade/ustep-01.md
+++ b/en/book/upgrade/ustep-01.md
@@ -71,3 +71,19 @@ want to preserve those. Here is a list of common customizations.
 
 If you realize after the upgrade that something was accidentally overwritten,
 don't panic -- that is why you started with a full backup. *(You did make a backup, right?)*
+
+## Check mainfile.php
+
+Old versions of XOOPS (i.e. 2.3) required some manual changes to be made in mainfile.php
+to enable the Protector module. In your web root you should have a file named
+`mainfile.php`. Open that file in your editor and look for these lines: 
+
+```PHP
+include XOOPS_TRUST_PATH.'/modules/protector/include/precheck.inc.php' ;
+```
+and
+```PHP
+include XOOPS_TRUST_PATH.'/modules/protector/include/postcheck.inc.php' ;
+```
+
+Remove these lines if you find them, and save the file before continuing.


### PR DESCRIPTION
Old versions of XOOPS required manual changes to mainfile.php to enable the protector module. These changes cause errors which will cause the upgrade to fail.

Add instructions to check for and remove such lines.

Also, add xoops_data copy instructions to the quick overview.